### PR TITLE
Ad/key class

### DIFF
--- a/lib/key.rb
+++ b/lib/key.rb
@@ -1,0 +1,8 @@
+class Key
+
+  def initialize(key)
+    @key = key
+  end 
+  
+
+endx

--- a/lib/key.rb
+++ b/lib/key.rb
@@ -1,8 +1,10 @@
 class Key
 
-  def initialize(key)
-    @key = key
+  attr_reader :digits
+
+  def initialize(key = '')
+    @digits = (key == '' ? (Array.new(5) { rand(1...9) }).join : key)
   end 
   
 
-endx
+end

--- a/lib/key.rb
+++ b/lib/key.rb
@@ -5,6 +5,9 @@ class Key
   def initialize(key = '')
     @digits = (key == '' ? (Array.new(5) { rand(1...9) }).join : key)
   end 
-  
+
+  def make_keys
+    [@digits[0..1].to_i, @digits[1..2].to_i, @digits[2..3].to_i, @digits[3..4].to_i]
+  end
 
 end

--- a/test/key_test.rb
+++ b/test/key_test.rb
@@ -1,0 +1,12 @@
+require 'minitest/autorun'
+require 'minitest/pride'
+require_relative '../lib/key'
+
+class KeyTest < Minitest::Test 
+
+  def test_it_exists
+    key = Key.new('03210')
+    assert_instance_of Key, key
+  end 
+  
+end

--- a/test/key_test.rb
+++ b/test/key_test.rb
@@ -1,6 +1,8 @@
 require 'minitest/autorun'
 require 'minitest/pride'
+require 'mocha/minitest'
 require_relative '../lib/key'
+
 
 class KeyTest < Minitest::Test 
 
@@ -8,5 +10,10 @@ class KeyTest < Minitest::Test
     key = Key.new('03210')
     assert_instance_of Key, key
   end 
-  
+
+  def test_it_can_be_initialized_with_a_serie_of_digits
+    key = Key.new('03210')
+    assert_equal '03210', key.digits
+  end
+
 end

--- a/test/key_test.rb
+++ b/test/key_test.rb
@@ -16,4 +16,19 @@ class KeyTest < Minitest::Test
     assert_equal '03210', key.digits
   end
 
+  def test_it_can_generate_its_own_serie_of_digits
+    key = mock('key')
+    key.stubs(:digits).returns('02132')
+    assert_equal '02132', key.digits
+  end
+
+  def test_it_can_return_the_keys_produced_from_the_digits
+    key1 = Key.new('03210')
+    assert_equal [3, 32, 21, 10], key1.make_keys
+    key2 = mock('key')
+    key2.stubs(:digits).returns('02132')
+    key2.stubs(:make_keys).returns([2, 21, 13, 32])
+    assert_equal [2, 21, 13, 32], key2.make_keys
+  end
+
 end


### PR DESCRIPTION
**Added the `Key` class tests and methods.**

`Key` objects are initialized with an optional 5-digit number passed as a string (`digits`). 
If no argument is passed, `digits` is assigned a random five-digit number converted to a string.

`make_key` uses the `digits` attribute to generate the keys used for encryption.


