### PR TITLE
Ad/offset class

### DIFF
--- a/lib/offset.rb
+++ b/lib/offset.rb
@@ -12,4 +12,9 @@ class Offset
     @date.to_i ** 2 
   end
 
+  def make_offsets
+    offset_digits = square_date.to_s.split('').map {|letter| letter.to_i}
+    offset_digits[-4..-1]
+  end
+
 end

--- a/lib/offset.rb
+++ b/lib/offset.rb
@@ -8,4 +8,8 @@ class Offset
     @date = date
   end
 
+  def square_date
+    @date.to_i ** 2 
+  end
+
 end

--- a/lib/offset.rb
+++ b/lib/offset.rb
@@ -1,0 +1,11 @@
+require 'date'
+
+class Offset
+
+  attr_reader :date
+
+  def initialize(date = Time.now.strftime('%d%m%y')) 
+    @date = date
+  end
+
+end

--- a/test/offset_test.rb
+++ b/test/offset_test.rb
@@ -19,4 +19,9 @@ class OffsetTest < Minitest::Test
     assert_equal '100120', offset2.date
   end
 
+  def test_it_can_return_the_square_date
+    offset = Offset.new('040895')
+    assert_equal 1672401025, offset.square_date
+  end
+
 end

--- a/test/offset_test.rb
+++ b/test/offset_test.rb
@@ -1,0 +1,22 @@
+require 'minitest/autorun'
+require 'minitest/pride'
+require 'mocha/minitest'
+require_relative '../lib/offset'
+
+class OffsetTest < Minitest::Test 
+
+  def test_it_exists 
+    offset = Offset.new('02715')
+    assert_instance_of Offset, offset
+  end 
+
+  def test_it_has_attributes
+    offset1 = Offset.new('040895')
+    assert_equal '040895', offset1.date
+
+    offset2 = mock('offset')
+    offset2.stubs(:date).returns('100120')
+    assert_equal '100120', offset2.date
+  end
+
+end

--- a/test/offset_test.rb
+++ b/test/offset_test.rb
@@ -24,4 +24,8 @@ class OffsetTest < Minitest::Test
     assert_equal 1672401025, offset.square_date
   end
 
+  def test_it_can_return_the_offset_values
+    offset = Offset.new('040895') 
+    assert_equal [1, 0, 2, 5] , offset.make_offsets 
+  end
 end


### PR DESCRIPTION
**Added the `Offset` class tests and methods.**

`Offset` objects are initialized with an optional date passed as a string.
If no argument is passed, date is assigned the date of the current day (format -> ddmmyy) converted to a string.

`make_offsets` uses the `date` attribute to generate the offset values used for encryption.