### PR TITLE
Ad/cryptor class

### DIFF
--- a/lib/cryptor.rb
+++ b/lib/cryptor.rb
@@ -1,0 +1,10 @@
+class Cryptor
+
+  def initialize(message, key, date) 
+    @message = message
+    @key = key
+    @date = date  
+  end 
+  
+
+end

--- a/lib/cryptor.rb
+++ b/lib/cryptor.rb
@@ -1,10 +1,11 @@
 class Cryptor
 
+  attr_reader :message, :key, :date
+
   def initialize(message, key, date) 
     @message = message
     @key = key
-    @date = date  
-  end 
-  
+    @date = date
+  end
 
 end

--- a/outline.txt
+++ b/outline.txt
@@ -15,7 +15,7 @@
         -------------  
       /               \
 ---------                   ---------           ---------              ---------           ---------            
-ENCRYPTOR                   DECRYPTOR             KEY                   OFFSET              CRACK
+ENCRYPTOR                   DECRYPTOR             KEY [x]               OFFSET [x]              CRACK
 @key = Key.new              initialize            initialize('34234')   initialize          initialize
 @offset = Offset.new                              make_keys()           make_offset() 
 @shift

--- a/test/cryptor_test.rb
+++ b/test/cryptor_test.rb
@@ -1,0 +1,12 @@
+require 'minitest/autorun'
+require 'minitest/pride'
+require_relative '../lib/cryptor'
+
+class CryptorTest < Minitest::Test 
+
+  def test_it_exists
+    cryptor = Cryptor.new("message", "01392", "100120")
+    assert_instance_of Cryptor, cryptor 
+  end
+
+end

--- a/test/cryptor_test.rb
+++ b/test/cryptor_test.rb
@@ -5,8 +5,15 @@ require_relative '../lib/cryptor'
 class CryptorTest < Minitest::Test 
 
   def test_it_exists
-    cryptor = Cryptor.new("message", "01392", "100120")
+    cryptor = Cryptor.new('message', '01392', '100120')
     assert_instance_of Cryptor, cryptor 
+  end
+
+  def test_it_has_attributes
+    cryptor = Cryptor.new('message', '01392', '100120')
+    assert_equal 'message', cryptor.message 
+    assert_equal '01392', cryptor.key 
+    assert_equal '100120', cryptor.date 
   end
 
 end


### PR DESCRIPTION
**Added the `Cryptor` super class tests and methods.**

`Cryptor` objects are initialized with a `message`, a `key` and a `date`.
`Encryptor` and `Decryptor` classes both inherit the `initialize` method from `Cryptor`