### PR TITLE
Ad/decryptor class

### DIFF
--- a/lib/decryptor.rb
+++ b/lib/decryptor.rb
@@ -4,11 +4,30 @@ require_relative './offset'
 
 class Decryptor < Cryptor
 
-  def initialize(message, key = '', date = '') 
+  attr_reader :decrypt_key, :decrypt_offset, :decrypt_shift
+
+  def initialize(message, key, date = '') 
     super(message, key, date) 
     @decrypt_key = Key.new(key)
     @decrypt_offset = (date == '' ? Offset.new : Offset.new(date))
-    @decrypt_shift = [@decrypt_key.make_keys, @decrypt_offset.make_offsets].transpose.map{|a| a.sum} 
+    @shift = [@decrypt_key.make_keys, @decrypt_offset.make_offsets].transpose.map{|a| a.sum} 
   end
-  
+
+  def unshifted_alphabet_positions
+    result = []
+    message_in_alphabet_positions.each_with_index do |position, index|
+      position.nil? ? result << position : result << (position - message_shifts[index]) % 27 
+    end
+    result
+  end
+
+  def decrypt
+    result = []
+    alphabet = ("a".."z").to_a << " "
+    unshifted_alphabet_positions.each_with_index do |position, index|
+      position.nil? ? result << @message[index] : result << alphabet[position]
+    end
+    { decryption: result.join, key: @decrypt_key.digits, date: @decrypt_offset.date }
+  end
+
 end

--- a/lib/decryptor.rb
+++ b/lib/decryptor.rb
@@ -1,0 +1,14 @@
+require_relative './cryptor'
+require_relative './key'
+require_relative './offset'
+
+class Decryptor < Cryptor
+
+  def initialize(message, key = '', date = '') 
+    super(message, key, date) 
+    @decrypt_key = Key.new(key)
+    @decrypt_offset = (date == '' ? Offset.new : Offset.new(date))
+    @decrypt_shift = [@decrypt_key.make_keys, @decrypt_offset.make_offsets].transpose.map{|a| a.sum} 
+  end
+  
+end

--- a/test/decryptor_test.rb
+++ b/test/decryptor_test.rb
@@ -8,6 +8,21 @@ class DecryptorTest < Minitest::Test
     decryptor = Decryptor.new('message', '01392', '100120')
     assert_instance_of  Decryptor, decryptor
   end 
-  
 
+  def test_it_can_return_an_array_of_alphabet_positions_for_a_message
+    decryptor = Decryptor.new('keder ohulw!!', '01392', '100120')
+    assert_equal [10, 4, 3, 4, 17, 26, 14, 7, 20, 11, 22, nil, nil], decryptor.message_in_alphabet_positions
+  end
+  
+  def test_it_can_return_an_array_of_unshifted_alphabet_positions
+    decryptor = Decryptor.new('keder ohulw!!', '01392', '100120')
+    assert_equal [5, 14, 18, 20, 12, 9, 2, 23, 15, 21, 10, nil, nil], decryptor.unshifted_alphabet_positions
+  end
+
+  def test_it_can_decrypt_a_given_message
+    decryptor = Decryptor.new("keder ohulw!!", '02715', '040895')
+    expected = { decryption: 'hello world!!' , key: '02715', date: '040895'}
+    assert_equal expected, decryptor.decrypt
+  end
+  
 end

--- a/test/decryptor_test.rb
+++ b/test/decryptor_test.rb
@@ -1,0 +1,13 @@
+require 'minitest/autorun'
+require 'minitest/pride'
+require_relative '../lib/decryptor'
+
+class DecryptorTest < Minitest::Test 
+
+  def test_it_exists 
+    decryptor = Decryptor.new('message', '01392', '100120')
+    assert_instance_of  Decryptor, decryptor
+  end 
+  
+
+end


### PR DESCRIPTION
**Added the `Decryptor` sub class tests and methods.**

`Decryptor` objects are initialized with a `message`, a `key` and a `date`. Upon initialization, a `key` and an `offset` objects are created to initialize the `decrypt_shift` array that contains the 4 shifts values used for decryption.

They respond to a `decrypt` method that returns a hash with the decrypted message, the `key` and the `date` used for decryption.

The message to be decrypted is first translated into an array of positions in the alphabet.

An array of shifts is then built with the same length as the array of positions (characters that do not belong to the alphabet or space are shifted by 0).

The array of positions and the array of shifts are subtracted from each other and multiples of the number of characters in the alphabet are removed from each new position value.

The resulting array of new positions in the alphabet is then converted back to letters.