### PR TITLE
Ad/refactor cryptor superclass and its subclasses

### DIFF
--- a/lib/cryptor.rb
+++ b/lib/cryptor.rb
@@ -2,10 +2,27 @@ class Cryptor
 
   attr_reader :message, :key, :date
 
-  def initialize(message, key, date) 
+  def initialize(message, key = '', date = '') 
     @message = message
     @key = key
     @date = date
   end
+
+  def message_in_alphabet_positions
+    alphabet = ("a".."z").to_a << " "
+    @message.split('').map {|letter| alphabet.find_index(letter)}
+  end
+
+  def message_shifts
+    shifts = []
+    (@message.length / @shift.length).times {shifts << @shift} 
+    shifts << @shift[0..(@message.length % @shift.length)-1]
+    shifts = shifts.flatten
+    message_in_alphabet_positions.each_with_index do |position, index| 
+      shifts[index] = 0  if position.nil?
+    end
+    shifts
+  end
+
 
 end

--- a/lib/encryptor.rb
+++ b/lib/encryptor.rb
@@ -4,29 +4,13 @@ require_relative './offset'
 
 class Encryptor < Cryptor
 
-  attr_reader :encrypt_key, :encrypt_offset, :encrypt_shift
+  attr_reader :encrypt_key, :encrypt_offset, :shift
 
   def initialize(message, key = '', date = '') 
     super(message, key, date) 
     @encrypt_key = Key.new(key)
     @encrypt_offset = (date == '' ? Offset.new : Offset.new(date))
-    @encrypt_shift = [@encrypt_key.make_keys, @encrypt_offset.make_offsets].transpose.map{|a| a.sum} 
-  end
-
-  def message_in_alphabet_positions
-    alphabet = ("a".."z").to_a << " "
-    @message.split('').map {|letter| alphabet.find_index(letter)}
-  end
- 
-  def message_shifts
-    shifts = []
-    (@message.length / @encrypt_shift.length).times {shifts << @encrypt_shift} 
-    shifts << @encrypt_shift[0..(@message.length % @encrypt_shift.length)-1]
-    shifts = shifts.flatten
-    message_in_alphabet_positions.each_with_index do |position, index| 
-      shifts[index] = 0  if position.nil?
-    end
-    shifts
+    @shift = [@encrypt_key.make_keys, @encrypt_offset.make_offsets].transpose.map{|a| a.sum} 
   end
 
   def shifted_alphabet_positions
@@ -45,6 +29,5 @@ class Encryptor < Cryptor
     end
     { encryption: result.join, key: @encrypt_key.digits, date: @encrypt_offset.date }
   end
-
 
 end

--- a/outline.txt
+++ b/outline.txt
@@ -15,16 +15,14 @@
         -------------  
       /               \
 ---------                   ---------           ---------              ---------           ---------            
-ENCRYPTOR                   DECRYPTOR             KEY [x]               OFFSET [x]              CRACK
+ENCRYPTOR[x]                DECRYPTOR             KEY [x]               OFFSET [x]              CRACK
 @key = Key.new              initialize            initialize('34234')   initialize          initialize
 @offset = Offset.new                              make_keys()           make_offset() 
 @shift
-initialize(key,offset,date)                        
+initialize(mess,key,date)                        
 encrypt(mes,key,date)       decrypt(mes,key,date) 
 
 enigma = Enigma.new
-
-
 
 Class Enigma 
 

--- a/test/cryptor_test.rb
+++ b/test/cryptor_test.rb
@@ -16,4 +16,9 @@ class CryptorTest < Minitest::Test
     assert_equal '100120', cryptor.date 
   end
 
+  def test_it_can_return_an_array_of_alphabet_positions_for_a_message
+    cryptor = Cryptor.new('message!!!', '01392', '100120')
+    assert_equal [12, 4, 18, 18, 0, 6, 4, nil, nil, nil], cryptor.message_in_alphabet_positions
+  end
+
 end

--- a/test/encryptor_test.rb
+++ b/test/encryptor_test.rb
@@ -20,14 +20,13 @@ class EncryptorTest < Minitest::Test
     assert_equal key.digits, encryptor.encrypt_key.digits
     assert_equal offset.date, encryptor.encrypt_offset.date
     expected = [key.make_keys, offset.make_offsets].transpose.map{|a| a.sum} 
-    assert_equal expected, encryptor.encrypt_shift
+    assert_equal expected, encryptor.shift
   end
 
   def test_it_can_return_an_array_of_alphabet_positions_for_a_message
     encryptor = Encryptor.new('message!!!', '01392', '100120')
     assert_equal [12, 4, 18, 18, 0, 6, 4, nil, nil, nil], encryptor.message_in_alphabet_positions
   end
-
 
   def test_it_can_return_an_array_of_shifts_for_a_message
     encryptor = Encryptor.new('message!!!', '01392', '100120')
@@ -42,6 +41,7 @@ class EncryptorTest < Minitest::Test
   def test_it_can_encrypt_a_given_message
 
     encryptor1 = Encryptor.new('hello world!!', '02715', '040895')
+    require 'pry'; binding.pry
     expected1 = {encryption: 'keder ohulw!!', key: encryptor1.encrypt_key.digits, date: encryptor1.encrypt_offset.date }
     assert_equal expected1, encryptor1.encrypt
 


### PR DESCRIPTION
Refactored `Cryptor` and the subclasses `Encryptor` and `Decryptor` to move the common methods to the superclass.

The methods that were rewritten and moved to `Cryptor` were: 
- `message_in_alphabet_positions`
- `message_shifts`