### PR TITLE
Ad/enigma class

### DIFF
--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -1,11 +1,16 @@
 require_relative './encryptor'
+require_relative './decryptor'
 
 class Enigma
 
-
-  def encrypt(message, key, date)
+  def encrypt(message, key ='', date='')
     encryptor = Encryptor.new(message, key, date)
     encryptor.encrypt
+  end
+
+  def decrypt(message, key, date='')
+    decryptor = Decryptor.new(message, key, date)
+    decryptor.decrypt
   end
 
 end

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -1,0 +1,11 @@
+require_relative './encryptor'
+
+class Enigma
+
+
+  def encrypt(message, key, date)
+    encryptor = Encryptor.new(message, key, date)
+    encryptor.encrypt
+  end
+
+end

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -1,0 +1,18 @@
+require 'minitest/autorun'
+require 'minitest/pride'
+require_relative '../lib/enigma'
+
+class EnigmaTest < Minitest::Test 
+
+  def test_it_exists 
+    enigma = Enigma.new
+    assert_instance_of Enigma, enigma
+  end
+  
+  def test_it_can_encrypt_a_message
+    enigma = Enigma.new
+    expected = { encryption: 'keder ohulw', key: '02715', date: '040895' }
+    assert_equal expected, enigma.encrypt('hello world', '02715', '040895')
+  end
+
+end

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -13,6 +13,21 @@ class EnigmaTest < Minitest::Test
     enigma = Enigma.new
     expected = { encryption: 'keder ohulw', key: '02715', date: '040895' }
     assert_equal expected, enigma.encrypt('hello world', '02715', '040895')
+
+    expected = { encryption: 'nib udmcxpu', key: '02715', date: '110120' }
+    assert_equal expected, enigma.encrypt('hello world', '02715')
+
+    # expected = { encryption: 'nib udmcxpu', key: '02715', date: '110120' }
+    # assert_equal expected, enigma.encrypt('hello world')
+  end
+
+    def test_it_can_decrypt_a_message
+    enigma = Enigma.new
+    expected = { decryption: 'hello world!!' , key: '02715', date: '040895'}
+    assert_equal expected, enigma.decrypt("keder ohulw!!", '02715', '040895')
+
+    expected = { decryption: 'hello world' , key: '02715', date: '110120'}
+    assert_equal expected, enigma.decrypt('nib udmcxpu', '02715')
   end
 
 end


### PR DESCRIPTION
**Added the `Enigma` class tests and methods.**

`Enigma` objects respond to an `encrypt` and a `decrypt` methods.  The `encrypt` method returns a hash with the encrypted `message`, the `key` and the `date` used for decryption. The `decrypt` method returns a hash with the decrypted `message`, the `key` and the `date` used for decryption.

Each method creates an `encryptor`/`decryptor` object on which the `encrypt`/`decrypt` methods are called.