### PR TITLE
Ad/include current date in all the tests that require it

### DIFF
--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -15,20 +15,23 @@ class EnigmaTest < Minitest::Test
     expected = { encryption: 'keder ohulw', key: '02715', date: '040895' }
     assert_equal expected, enigma.encrypt('hello world', '02715', '040895')
 
-    expected = { encryption: 'nib udmcxpu', key: '02715', date: '110120' }
+    expected = { encryption: 'nib udmcxpu', key: '02715', date: Time.now.strftime('%d%m%y') }
     assert_equal expected, enigma.encrypt('hello world', '02715')
-
-    # expected = { encryption: 'nib udmcxpu', key: '02715', date: '110120' }
-    # assert_equal expected, enigma.encrypt('hello world')
   end
 
-    def test_it_can_decrypt_a_message
+  def test_it_can_decrypt_a_message
     enigma = Enigma.new
     expected = { decryption: 'hello world!!' , key: '02715', date: '040895'}
     assert_equal expected, enigma.decrypt("keder ohulw!!", '02715', '040895')
 
-    expected = { decryption: 'hello world' , key: '02715', date: '110120'}
+    expected = { decryption: 'hello world' , key: '02715', date: Time.now.strftime('%d%m%y')}
     assert_equal expected, enigma.decrypt('nib udmcxpu', '02715')
+  end
+
+  def test_it_can_crack_a_message
+    enigma = Enigma.new
+    expected = { decryption: 'hello world end', date: '291018', key: '08304' }
+    assert_equal expected, enigma.crack('vjqtbeaweqihssi', '291018')
   end
 
 end


### PR DESCRIPTION
Modified the tests to replace hardcoded current `date` by actual current date (using `Time.now.strftime('%d%m%y')`