### PR TITLE
Ad/refactor the initialize methods of cryptor, encryptor and decryptor

### DIFF
--- a/lib/cracking.rb
+++ b/lib/cracking.rb
@@ -1,8 +1,9 @@
-require_relative './cryptor'
 require_relative './decryptor'
 
 
-class Cracking < Cryptor
+class Cracking
+
+  attr_reader :message, :date
 
   def initialize(message, date = Time.now.strftime('%d%m%y')) 
     @message = message 
@@ -16,8 +17,7 @@ class Cracking < Cryptor
   end
 
   def find_key_from_date
-    count = 0
-    key = make_key_string(count)
+    count, key = 0, make_key_string(count)
     decryptor = Decryptor.new(@message, key, @date)
     output = decryptor.decrypt
     while (output[:decryption][-4..-1] != ' end') && (count < 100000)

--- a/lib/cryptor.rb
+++ b/lib/cryptor.rb
@@ -1,15 +1,13 @@
 class Cryptor
 
-  attr_reader :message, :key, :date
+  attr_reader :message
 
-  def initialize(message, key = '', date = '') 
-    @message = message
-    @key = key
-    @date = date
+  def initialize(message)
+    @message = message.downcase
   end
 
   def message_in_alphabet_positions
-    alphabet = ("a".."z").to_a << " "
+    alphabet = ('a'..'z').to_a << ' '
     @message.split('').map {|letter| alphabet.find_index(letter)}
   end
 

--- a/lib/decryptor.rb
+++ b/lib/decryptor.rb
@@ -5,12 +5,11 @@ require_relative './offset'
 class Decryptor < Cryptor
 
   attr_reader :decrypt_key, :decrypt_offset, :decrypt_shift
-  attr_accessor :shift
 
-  def initialize(message, key, date = '') 
-    super(message, key, date) 
+  def initialize(message, key, date = '')
+    super(message)
     @decrypt_key = Key.new(key)
-    @decrypt_offset = (date == '' ? Offset.new : Offset.new(date))
+    @decrypt_offset = Offset.new(date)
     @shift = [@decrypt_key.make_keys, @decrypt_offset.make_offsets].transpose.map{|a| a.sum} 
   end
 

--- a/lib/encryptor.rb
+++ b/lib/encryptor.rb
@@ -7,9 +7,9 @@ class Encryptor < Cryptor
   attr_reader :encrypt_key, :encrypt_offset, :shift
 
   def initialize(message, key = '', date = '') 
-    super(message, key, date) 
+    super(message)
     @encrypt_key = Key.new(key)
-    @encrypt_offset = (date == '' ? Offset.new : Offset.new(date))
+    @encrypt_offset = Offset.new(date)
     @shift = [@encrypt_key.make_keys, @encrypt_offset.make_offsets].transpose.map{|a| a.sum} 
   end
 
@@ -23,7 +23,7 @@ class Encryptor < Cryptor
 
   def encrypt
     result = []
-    alphabet = ("a".."z").to_a << " "
+    alphabet = ('a'..'z').to_a << ' '
     shifted_alphabet_positions.each_with_index do |position, index|
       position.nil? ? result << @message[index] : result << alphabet[position]
     end

--- a/lib/offset.rb
+++ b/lib/offset.rb
@@ -4,8 +4,12 @@ class Offset
 
   attr_reader :date
 
-  def initialize(date = Time.now.strftime('%d%m%y')) 
-    @date = date
+  def initialize(date)
+    if date == ''
+      @date = Time.now.strftime('%d%m%y')
+    else
+      @date = date
+    end
   end
 
   def square_date

--- a/test/cracking_test.rb
+++ b/test/cracking_test.rb
@@ -11,6 +11,12 @@ class CrackingTest < Minitest::Test
     assert_instance_of Cracking, crack 
   end
 
+  def test_it_has_attributes
+    crack = Cracking.new('vjqtbeaweqihssi', '291018')
+    assert_equal 'vjqtbeaweqihssi', crack.message
+    assert_equal '291018', crack.date
+  end
+
   def test_it_can_make_a_key_string_from_a_number
     crack = Cracking.new('vjqtbeaweqihssi', '291018')
     assert_equal '00231', crack.make_key_string(231)

--- a/test/cryptor_test.rb
+++ b/test/cryptor_test.rb
@@ -6,19 +6,17 @@ require_relative '../lib/cryptor'
 class CryptorTest < Minitest::Test 
 
   def test_it_exists
-    cryptor = Cryptor.new('message', '01392', '100120')
+    cryptor = Cryptor.new('message')
     assert_instance_of Cryptor, cryptor 
   end
 
   def test_it_has_attributes
-    cryptor = Cryptor.new('message', '01392', '100120')
+    cryptor = Cryptor.new('message')
     assert_equal 'message', cryptor.message 
-    assert_equal '01392', cryptor.key 
-    assert_equal '100120', cryptor.date 
   end
 
   def test_it_can_return_an_array_of_alphabet_positions_for_a_message
-    cryptor = Cryptor.new('message!!!', '01392', '100120')
+    cryptor = Cryptor.new('message!!!')
     assert_equal [12, 4, 18, 18, 0, 6, 4, nil, nil, nil], cryptor.message_in_alphabet_positions
   end
 

--- a/test/decryptor_test.rb
+++ b/test/decryptor_test.rb
@@ -10,6 +10,12 @@ class DecryptorTest < Minitest::Test
     assert_instance_of  Decryptor, decryptor
   end 
 
+  def test_it_has_attributes 
+    decryptor = Decryptor.new('message', '01392', '100120')
+    assert_instance_of Key, decryptor.decrypt_key
+    assert_instance_of Offset, decryptor.decrypt_offset
+  end
+
   def test_it_can_return_an_array_of_alphabet_positions_for_a_message
     decryptor = Decryptor.new('keder ohulw!!', '01392', '100120')
     assert_equal [10, 4, 3, 4, 17, 26, 14, 7, 20, 11, 22, nil, nil], decryptor.message_in_alphabet_positions

--- a/test/encryptor_test.rb
+++ b/test/encryptor_test.rb
@@ -16,8 +16,6 @@ class EncryptorTest < Minitest::Test
     key = Key.new('01392')
     offset = Offset.new('100120')
     assert_equal 'message', encryptor.message 
-    assert_equal '01392', encryptor.key 
-    assert_equal '100120', encryptor.date 
     assert_equal key.digits, encryptor.encrypt_key.digits
     assert_equal offset.date, encryptor.encrypt_offset.date
     expected = [key.make_keys, offset.make_offsets].transpose.map{|a| a.sum} 


### PR DESCRIPTION
**Removed class attributes redundancy in the `Cryptor`, `Decryptor` and `Encryptor` classes.**

the `Decryptor` and `Encryptor` classes now inherit the methods from `Cryptor` as well as the `message` instance variable. Since the `key` and `offset` instance variable were only used to instantiate the `encrypt_key` and `encrypt_offset` objects, `Encryptor` and `Decryptor` objects are no longer initialized with these instance variables.

Test of each of these classes were changed accordingly.