### PR TITLE
Ad/add mocks and stubs to Cracking, Encryptor, Key and Offset class tests

### DIFF
--- a/lib/cryptor.rb
+++ b/lib/cryptor.rb
@@ -8,19 +8,18 @@ class Cryptor
 
   def message_in_alphabet_positions
     alphabet = ('a'..'z').to_a << ' '
-    @message.split('').map {|letter| alphabet.find_index(letter)}
+    message.split('').map {|letter| alphabet.find_index(letter)}
   end
 
   def message_shifts
     shifts = []
-    (@message.length / @shift.length).times {shifts << @shift} 
-    shifts << @shift[0..(@message.length % @shift.length)-1]
+    (message.length / shift.length).times {shifts << shift} 
+    shifts << shift[0..(message.length % shift.length)-1]
     shifts = shifts.flatten
     message_in_alphabet_positions.each_with_index do |position, index| 
       shifts[index] = 0  if position.nil?
     end
     shifts
   end
-
 
 end

--- a/lib/decryptor.rb
+++ b/lib/decryptor.rb
@@ -4,13 +4,13 @@ require_relative './offset'
 
 class Decryptor < Cryptor
 
-  attr_reader :decrypt_key, :decrypt_offset, :decrypt_shift
+  attr_reader :decrypt_key, :decrypt_offset, :shift
 
   def initialize(message, key, date = '')
     super(message)
     @decrypt_key = Key.new(key)
     @decrypt_offset = Offset.new(date)
-    @shift = [@decrypt_key.make_keys, @decrypt_offset.make_offsets].transpose.map{|a| a.sum} 
+    @shift = [decrypt_key.make_keys, decrypt_offset.make_offsets].transpose.map{|a| a.sum} 
   end
 
   def unshifted_alphabet_positions

--- a/lib/encryptor.rb
+++ b/lib/encryptor.rb
@@ -27,7 +27,7 @@ class Encryptor < Cryptor
     shifted_alphabet_positions.each_with_index do |position, index|
       position.nil? ? result << @message[index] : result << alphabet[position]
     end
-    { encryption: result.join, key: @encrypt_key.digits, date: @encrypt_offset.date }
+    { encryption: result.join, key: encrypt_key.digits, date: encrypt_offset.date }
   end
 
 end

--- a/lib/key.rb
+++ b/lib/key.rb
@@ -3,11 +3,15 @@ class Key
   attr_reader :digits
 
   def initialize(key = '')
-    @digits = (key == '' ? (Array.new(5) { rand(1...9) }).join : key)
+    if key == ''
+      @digits = (Array.new(5) { rand(0...9) }).join
+    else
+      @digits = key
+    end
   end 
 
   def make_keys
-    [@digits[0..1].to_i, @digits[1..2].to_i, @digits[2..3].to_i, @digits[3..4].to_i]
+    [digits[0..1].to_i, digits[1..2].to_i, digits[2..3].to_i, digits[3..4].to_i]
   end
 
 end

--- a/lib/offset.rb
+++ b/lib/offset.rb
@@ -13,7 +13,7 @@ class Offset
   end
 
   def square_date
-    @date.to_i ** 2 
+    date.to_i ** 2 
   end
 
   def make_offsets

--- a/test/cracking_test.rb
+++ b/test/cracking_test.rb
@@ -1,6 +1,7 @@
 require_relative '../test_helper'
 require 'minitest/autorun'
 require 'minitest/pride'
+require 'mocha/minitest'
 require_relative '../lib/cracking'
 require_relative '../lib/encryptor'
 
@@ -32,10 +33,15 @@ class CrackingTest < Minitest::Test
     expected = { decryption: 'hello world end', date: '291018', key: '08304' }
     assert_equal expected, crack.crack
 
-    encryptor = Encryptor.new('message is this end')
+    encryptor = Encryptor.new('message is that it is hard to decrypt end', '08304')
     output = encryptor.encrypt 
     crack = Cracking.new(output[:encryption])
-    expected = { decryption: 'message is this end', date: Time.now.strftime('%d%m%y'), key: output[:key] }
+    crack.stubs(:find_key_from_date).returns('08304')
+    expected = { 
+                decryption: 'message is that it is hard to decrypt end', 
+                date: Time.now.strftime('%d%m%y'), 
+                key: output[:key] 
+                }
     assert_equal expected, crack.crack 
   end
 

--- a/test/encryptor_test.rb
+++ b/test/encryptor_test.rb
@@ -42,17 +42,18 @@ class EncryptorTest < Minitest::Test
     encryptor1 = Encryptor.new('hello world!!', '02715', '040895')
     expected1 = {encryption: 'keder ohulw!!', key: encryptor1.encrypt_key.digits, date: encryptor1.encrypt_offset.date }
     assert_equal expected1, encryptor1.encrypt
-
-    # encryptor2 = Encryptor.new('hello world!!')
-    # key = mock('key')
-    # key.stubs(:digits).returns('28563')
-    # offset = mock('offset')
-    # offset.stubs(:date).returns('110120')
-    # encryptor2.stubs(:encrypt_key).returns(key)
-    # encryptor2.stubs(:encrypt_shift).returns([32, 89, 56, 63])
-    # encryptor2.stubs(:encrypt_offset).returns(offset)
-    # expected2 = {encryption: 'mmnuthyxwtf!!', key: encryptor2.encrypt_key.digits, date: encryptor2.encrypt_offset.date }
-    # assert_equal expected2, encryptor2.encrypt
+    
+    encryptor2 = Encryptor.new('hello world!!')
+    encryptor2.stubs(:message).returns('hello world!!')
+    key = Key.new
+    key.stubs(:digits).returns('28563')
+    offset = Offset.new
+    offset.stubs(:date).returns('110120')
+    encryptor2.stubs(:encrypt_key).returns(key)
+    encryptor2.stubs(:shift).returns([32, 89, 56, 63])
+    encryptor2.stubs(:encrypt_offset).returns(offset)
+    expected2 = {encryption: 'mmnuthyxwtf!!', key: encryptor2.encrypt_key.digits, date: encryptor2.encrypt_offset.date }
+    assert_equal expected2, encryptor2.encrypt
   end
 
 end

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -22,7 +22,7 @@ class EnigmaTest < Minitest::Test
   def test_it_can_decrypt_a_message
     enigma = Enigma.new
     expected = { decryption: 'hello world!!' , key: '02715', date: '040895'}
-    assert_equal expected, enigma.decrypt("keder ohulw!!", '02715', '040895')
+    assert_equal expected, enigma.decrypt('keder ohulw!!', '02715', '040895')
 
     expected = { decryption: 'hello world' , key: '02715', date: Time.now.strftime('%d%m%y')}
     assert_equal expected, enigma.decrypt('nib udmcxpu', '02715')

--- a/test/key_test.rb
+++ b/test/key_test.rb
@@ -26,9 +26,8 @@ class KeyTest < Minitest::Test
   def test_it_can_return_the_keys_produced_from_the_digits
     key1 = Key.new('03210')
     assert_equal [3, 32, 21, 10], key1.make_keys
-    key2 = mock('key')
+    key2 = Key.new
     key2.stubs(:digits).returns('02132')
-    key2.stubs(:make_keys).returns([2, 21, 13, 32])
     assert_equal [2, 21, 13, 32], key2.make_keys
   end
 

--- a/test/offset_test.rb
+++ b/test/offset_test.rb
@@ -9,15 +9,18 @@ class OffsetTest < Minitest::Test
   def test_it_exists 
     offset = Offset.new('02715')
     assert_instance_of Offset, offset
+
+    offset = Offset.new
+    assert_instance_of Offset, offset
   end 
 
   def test_it_has_attributes
     offset1 = Offset.new('040895')
     assert_equal '040895', offset1.date
 
-    offset2 = mock('offset')
-    offset2.stubs(:date).returns('100120')
-    assert_equal '100120', offset2.date
+    offset2 = Offset.new
+    offset2.stubs(:date).returns('150120')
+    assert_equal '150120', offset2.date
   end
 
   def test_it_can_return_the_square_date
@@ -26,7 +29,11 @@ class OffsetTest < Minitest::Test
   end
 
   def test_it_can_return_the_offset_values
-    offset = Offset.new('040895') 
-    assert_equal [1, 0, 2, 5] , offset.make_offsets 
+    offset1 = Offset.new('040895') 
+    assert_equal [1, 0, 2, 5] , offset1.make_offsets
+    offset2 = Offset.new
+    offset2.stubs(:date).returns('140120')
+    assert_equal [4, 4, 0, 0] , offset2.make_offsets
   end
+
 end


### PR DESCRIPTION
**Added mocks and stubs to the tests of the classes `Cracking`, `Encryptor`, `Key` and `Offset`**

Mocks and stubs were used to test methods that required randomness and to speed up the testing of methods whose setup was taking a long time to execute (see the tests for the `Cracking` class).